### PR TITLE
adds getter for id of requests response

### DIFF
--- a/lib/xolphin/api/responses/requests.rb
+++ b/lib/xolphin/api/responses/requests.rb
@@ -19,6 +19,10 @@ module Xolphin
             requests
           end
         end
+
+        def id
+          @data["id"]
+        end
       end
     end
   end


### PR DESCRIPTION
Matches getter method in the `Request` response so we can easily get the order id when sending a renew request like we do for normal requests.